### PR TITLE
Adds Composer require functionality

### DIFF
--- a/src/components/TerminalView.vue
+++ b/src/components/TerminalView.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
-import { ref, nextTick } from 'vue'
+import { ref, computed, nextTick } from 'vue'
 import { usePhp } from '../composables/usePhp'
 
-const { runArtisan, collectVfsPaths } = usePhp()
+const { runArtisan, runComposerRequire } = usePhp()
 
 const inputValue = ref('')
 const running = ref(false)
 const outputEl = ref<HTMLDivElement | null>(null)
+const commandType = ref<'artisan' | 'composer'>('artisan')
 
 const commandHistory: string[] = []
 let historyIndex = -1
@@ -16,8 +17,12 @@ interface OutputEntry {
 }
 
 const outputEntries = ref<OutputEntry[]>([
-  { html: '<div class="text-stone-400">Laravel Artisan — type a command below to run it.</div>' },
+  { html: '<div class="text-stone-400">Laravel Terminal — use the dropdown to switch between Artisan and Composer modes.</div>' },
 ])
+
+const placeholder = computed(() =>
+  commandType.value === 'artisan' ? 'e.g. make:model Post' : 'e.g. spatie/laravel-sluggable'
+)
 
 function escapeHtml(str: string) {
   return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
@@ -41,27 +46,49 @@ async function run() {
   commandHistory.push(trimmed)
   historyIndex = commandHistory.length
 
-  appendOutput(`<div class="mt-3 text-stone-500">$ php artisan ${escapeHtml(trimmed)}</div>`)
+  if (commandType.value === 'artisan') {
+    appendOutput(`<div class="mt-3 text-stone-500">$ php artisan ${escapeHtml(trimmed)}</div>`)
 
-  try {
-    const { output, errors } = await runArtisan(trimmed)
+    try {
+      const { output, errors } = await runArtisan(trimmed)
 
-    if (output) {
-      appendOutput(`<pre class="text-stone-700 whitespace-pre-wrap">${escapeHtml(output)}</pre>`)
+      if (output) {
+        appendOutput(`<pre class="text-stone-700 dark:text-stone-300 whitespace-pre-wrap">${escapeHtml(output)}</pre>`)
+      }
+      if (errors) {
+        appendOutput(`<pre class="text-red-600 whitespace-pre-wrap">${escapeHtml(errors)}</pre>`)
+      }
+      if (!output && !errors) {
+        appendOutput(`<div class="text-stone-400 italic">Command completed with no output.</div>`)
+      }
+    } catch (err: any) {
+      appendOutput(`<pre class="text-red-600 whitespace-pre-wrap">${escapeHtml(err.message)}</pre>`)
+      console.error(err)
     }
-    if (errors) {
-      appendOutput(`<pre class="text-red-600 whitespace-pre-wrap">${escapeHtml(errors)}</pre>`)
+  } else {
+    appendOutput(`<div class="mt-3 text-stone-500">$ composer require ${escapeHtml(trimmed)}</div>`)
+    appendOutput(`<div class="text-stone-400 italic">Fetching package info...</div>`)
+
+    try {
+      const { output, errors } = await runComposerRequire(trimmed)
+
+      if (output) {
+        appendOutput(`<pre class="text-stone-700 dark:text-stone-300 whitespace-pre-wrap">${escapeHtml(output)}</pre>`)
+      }
+      if (errors) {
+        appendOutput(`<pre class="text-red-600 whitespace-pre-wrap">${escapeHtml(errors)}</pre>`)
+      }
+      if (!output && !errors) {
+        appendOutput(`<div class="text-stone-400 italic">Command completed with no output.</div>`)
+      }
+    } catch (err: any) {
+      appendOutput(`<pre class="text-red-600 whitespace-pre-wrap">${escapeHtml(err.message)}</pre>`)
+      console.error(err)
     }
-    if (!output && !errors) {
-      appendOutput(`<div class="text-stone-400 italic">Command completed with no output.</div>`)
-    }
-  } catch (err: any) {
-    appendOutput(`<pre class="text-red-600 whitespace-pre-wrap">${escapeHtml(err.message)}</pre>`)
-    console.error(err)
-  } finally {
-    running.value = false
-    inputValue.value = ''
   }
+
+  running.value = false
+  inputValue.value = ''
 }
 
 function onKeydown(e: KeyboardEvent) {
@@ -92,7 +119,13 @@ function onKeydown(e: KeyboardEvent) {
       <div v-for="(entry, i) in outputEntries" :key="i" v-html="entry.html"></div>
     </div>
     <div class="panel-terminal-input border-t border-stone-200 dark:border-stone-700 bg-white dark:bg-stone-900 px-4 pt-3 pb-8 md:py-3 shrink-0 flex items-center gap-2">
-      <span class="text-xs font-mono text-stone-400 dark:text-stone-500 shrink-0">php artisan</span>
+      <select
+        v-model="commandType"
+        class="text-xs font-mono text-stone-500 dark:text-stone-400 bg-stone-50 dark:bg-stone-800 border border-stone-200 dark:border-stone-700 rounded-md px-1.5 py-1 outline-none focus:border-stone-400 dark:focus:border-stone-500 shrink-0 cursor-pointer"
+      >
+        <option value="artisan">php artisan</option>
+        <option value="composer">composer require</option>
+      </select>
       <input
         v-model="inputValue"
         type="text"
@@ -100,7 +133,7 @@ function onKeydown(e: KeyboardEvent) {
         autocapitalize="off"
         autocorrect="off"
         :disabled="running"
-        placeholder="e.g. make:model Post"
+        :placeholder="placeholder"
         class="flex-1 px-2 py-1 text-sm font-mono bg-stone-50 dark:bg-stone-800 border border-stone-200 dark:border-stone-700 rounded-md text-stone-700 dark:text-stone-200 outline-none focus:border-stone-400 dark:focus:border-stone-500 focus:bg-white dark:focus:bg-stone-700 disabled:opacity-50 disabled:cursor-not-allowed"
         @keydown="onKeydown"
       />

--- a/src/composables/usePhp.ts
+++ b/src/composables/usePhp.ts
@@ -196,17 +196,11 @@ export function usePhp() {
         return { output: '', errors: `No dist URL found for ${packageName}@${version}.` }
       }
 
-      // 2. Download the zip from GitHub archive
-      const ref = stable.dist?.reference || 'main'
-      const ghMatch = distUrl.match(/github\.com\/([^/]+)\/([^/]+)\//)
-      let zipUrl: string
-      if (ghMatch) {
-        zipUrl = `https://github.com/${ghMatch[1]}/${ghMatch[2]}/archive/refs/heads/${ref}.zip`
-      } else {
-        zipUrl = distUrl
-      }
-
-      const zipRes = await fetch(zipUrl)
+      // 2. Download the zip via CORS proxy
+      const zipRes = await fetch(`https://cors-anywhere.com/${distUrl}`, {
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+        redirect: 'follow',
+      })
       if (!zipRes.ok) {
         return { output: '', errors: `Failed to download package zip (HTTP ${zipRes.status}).` }
       }

--- a/src/composables/usePhp.ts
+++ b/src/composables/usePhp.ts
@@ -174,18 +174,18 @@ export function usePhp() {
 
     try {
       // 1. Fetch package metadata from Packagist
-      const metaRes = await fetch(`https://repo.packagist.org/p2/${vendor}/${name}.json`)
+      const metaRes = await fetch(`https://packagist.org/packages/${vendor}/${name}.json`)
       if (!metaRes.ok) {
         return { output: '', errors: `Package "${packageName}" not found on Packagist.` }
       }
       const meta = await metaRes.json()
-      const versions = meta.packages?.[packageName] ?? []
+      const versionsObj = meta.package?.versions ?? {}
 
       // Pick latest stable version (no dev/alpha/beta/RC)
-      const stable = versions.find((v: any) => {
+      const stable = Object.values(versionsObj).find((v: any) => {
         const ver: string = v.version || ''
         return !ver.includes('dev') && !ver.includes('alpha') && !ver.includes('beta') && !ver.includes('RC')
-      })
+      }) as any
       if (!stable) {
         return { output: '', errors: `No stable version found for "${packageName}".` }
       }

--- a/src/composables/usePhp.ts
+++ b/src/composables/usePhp.ts
@@ -227,7 +227,8 @@ export function usePhp() {
 
       // Find the common prefix (most zips have a single root folder)
       const allPaths = zipFiles.map(([p]) => p)
-      const prefix = allPaths.length > 0 ? allPaths[0].split('/')[0] + '/' : ''
+      const firstPath = allPaths[0]
+      const prefix = firstPath ? firstPath.split('/')[0] + '/' : ''
       const hasCommonPrefix = prefix && allPaths.every(p => p.startsWith(prefix))
 
       const vendorBase = `/app/vendor/${vendor}/${name}`


### PR DESCRIPTION
This PR adds functionality to enable a facade of `composer require` through TypeScript and the underlying wasm virtual filesystem (fixes #1).

Uses packagist as an open API to determine latest zip of package code, then downloads and injects that code into the virtual filesystem in the appropriate vendor directory. 

Handles an attempt at reconfiguring `composer dump-autoload` afterwards for appropriate dependency injection of the new class(es).